### PR TITLE
Fix insecure error during logout

### DIFF
--- a/laravel/bootstrap/app.php
+++ b/laravel/bootstrap/app.php
@@ -11,7 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->trustProxies(at: '*');
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
Since we are using a proxy this line needs to be added, otherwise the entire filament panel will be insecure and will cause issues when logging out.